### PR TITLE
Fix scroll position on results screen

### DIFF
--- a/calculadora_inmueble.py
+++ b/calculadora_inmueble.py
@@ -883,89 +883,17 @@ elif st.session_state.step == 2:
 
 
 elif st.session_state.step == 3:
-    # Enhanced scroll to top with more aggressive methods
-    st.markdown("""
-    <script>
-    function forceScrollToTop() {
-        console.log('Attempting to scroll to top...');
-        
-        // Method 1: Direct window scroll
-        try {
-            window.scrollTo({top: 0, behavior: 'instant'});
-            window.scrollTo(0, 0);
-        } catch(e) {}
-        
-        // Method 2: Parent window scroll  
-        try {
-            if (window.parent && window.parent !== window) {
-                window.parent.scrollTo({top: 0, behavior: 'instant'});
-                window.parent.scrollTo(0, 0);
-            }
-        } catch(e) {}
-        
-        // Method 3: Document element scroll
-        try {
-            document.documentElement.scrollTop = 0;
-            document.body.scrollTop = 0;
-        } catch(e) {}
-        
-        // Method 4: Parent document scroll
-        try {
-            if (window.parent && window.parent.document) {
-                window.parent.document.documentElement.scrollTop = 0;
-                window.parent.document.body.scrollTop = 0;
-            }
-        } catch(e) {}
-        
-        // Method 5: Find and scroll all possible containers
-        try {
-            const allDocs = [document];
-            if (window.parent && window.parent.document && window.parent.document !== document) {
-                allDocs.push(window.parent.document);
-            }
-            
-            allDocs.forEach(doc => {
-                // Streamlit main container
-                const containers = doc.querySelectorAll('[data-testid="stAppViewContainer"], .main, .stApp, [data-testid="main"]');
-                containers.forEach(container => {
-                    container.scrollTop = 0;
-                    container.scrollTo && container.scrollTo(0, 0);
-                });
-                
-                // All scrollable elements
-                const scrollables = doc.querySelectorAll('*');
-                scrollables.forEach(el => {
-                    if (el.scrollTop > 0) {
-                        el.scrollTop = 0;
-                    }
-                });
-            });
-        } catch(e) {}
-    }
-    
-    // Execute multiple times with different delays
-    forceScrollToTop();
-    setTimeout(forceScrollToTop, 50);
-    setTimeout(forceScrollToTop, 100);
-    setTimeout(forceScrollToTop, 200);
-    setTimeout(forceScrollToTop, 500);
-    setTimeout(forceScrollToTop, 1000);
-    
-    // Listen for various events
-    document.addEventListener('DOMContentLoaded', forceScrollToTop);
-    window.addEventListener('load', forceScrollToTop);
-    
-    // Create an intersection observer to trigger when content loads
-    if (window.IntersectionObserver) {
-        const observer = new IntersectionObserver((entries) => {
-            setTimeout(forceScrollToTop, 100);
-        });
-        observer.observe(document.body);
-    }
-    </script>
-    """, unsafe_allow_html=True)
-    
-    # Add an anchor point at the top of results
+    # Ensure the page loads at the start of the results
+    st.components.v1.html(
+        """
+        <script>
+        function scrollTop() { window.scrollTo(0, 0); }
+        window.addEventListener('load', scrollTop);
+        setTimeout(scrollTop, 100);
+        </script>
+        """,
+        height=0,
+    )
     st.markdown('<div id="top-of-results"></div>', unsafe_allow_html=True)
     
     d = st.session_state.inputs


### PR DESCRIPTION
## Summary
- refine JS that resets scroll at start of results page so browser stays at top

## Testing
- `python -m py_compile calculadora_inmueble.py`


------
https://chatgpt.com/codex/tasks/task_e_68888c22c1308322b540cf502d808753